### PR TITLE
Updated the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-include $(GOROOT)/src/Make.$(GOARCH)
+include $(GOROOT)/src/Make.inc
 
 TARG=sqlite3
 


### PR DESCRIPTION
Hey, correct me if I'm wrong, but the current version of Go seems to use a new initial Makefile include.
I've updated the Makefile for gosqlite3 to use '.inc' instead.
